### PR TITLE
Hide two_factor_reset_code from User serialization

### DIFF
--- a/install-stubs/app/User.php
+++ b/install-stubs/app/User.php
@@ -27,6 +27,7 @@ class User extends SparkUser
         'authy_id',
         'country_code',
         'phone',
+        'two_factor_reset_code',
         'card_brand',
         'card_last_four',
         'card_country',


### PR DESCRIPTION
Hid this in my applications since it's a bcrypted value. Figured it would be prudent to add it to the core.