### PR TITLE
pass class / method ref to checkTeamPlanEligibilityUsing

### DIFF
--- a/src/Configuration/CallsInteractions.php
+++ b/src/Configuration/CallsInteractions.php
@@ -150,7 +150,7 @@ trait CallsInteractions
      * @param  \Closure  $callback
      * @return void
      */
-    public static function checkTeamPlanEligibilityUsing(Closure $callback)
+    public static function checkTeamPlanEligibilityUsing($callback)
     {
         static::swap('CheckTeamPlanEligibility@handle', $callback);
     }


### PR DESCRIPTION
Allow a string to pass a class / method reference to `checkTeamPlanEligibilityUsing` like what can be done with `checkPlanEligibilityUsing`.