### PR TITLE
Update _tables.scss

### DIFF
--- a/resources/assets/sass/elements/_tables.scss
+++ b/resources/assets/sass/elements/_tables.scss
@@ -28,11 +28,11 @@
 
 .table-plan-price {
   font-weight: 600;
-  color: gray-800;
+  color: $gray-800;
 }
 
 .table-plan-text {
-  color: gray-600;
+  color: $gray-600;
 }
 
 .card {


### PR DESCRIPTION
Typo. Missing $ in front of variables $gray-800 and $gray-600 on .table-plan-price and .table-plan-text