### PR TITLE
Add withAccessToken method

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -52,4 +52,17 @@ trait HasApiTokens
 
         return $this;
     }
+    
+    /**
+     * Set the current access token for the user.
+     *
+     * @param  \Laravel\Spark\Token  $accessToken
+     * @return $this
+     */
+    public function withAccessToken($accessToken)
+    {
+        $this->currentToken = $accessToken;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## Scenario and Issue

After installing Passport into a Spark app, I enabled OAuth with password grant tokens. Everything works great except that Passport expects the method `withAccessToken` on the User object. 

## Fix

This PR adds the `withAccessToken` method to the Spark `HasApiTokens` trait that exists on the base user object. This is almost just a copy and paste from the original in Passport.

## Alternative Solutions

There are of course a couple other options. I could add this method directly to the user object, or I can use both the Passport `HasApiTokens` trait and the Spark equivalent. The second option requires specifying which methods come from where using the weird `insteadof` syntax. This seems like the most straightforward option though.

