### PR TITLE
Specify the team_id foreign key

### DIFF
--- a/src/Team.php
+++ b/src/Team.php
@@ -94,7 +94,7 @@ class Team extends Model
      */
     public function invitations()
     {
-        return $this->hasMany(Invitation::class);
+        return $this->hasMany(Invitation::class, 'team_id');
     }
 
     /**


### PR DESCRIPTION
The invitations query could be failed if developers use a custom team class other than `App\Team`.

Fixed by manually specify the foreign key.