### PR TITLE
format router

### DIFF
--- a/install-stubs/app/Providers/RouteServiceProvider.php
+++ b/install-stubs/app/Providers/RouteServiceProvider.php
@@ -66,9 +66,9 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function mapApiRoutes(Router $router)
     {
-         $router->prefix('api')
-                ->middleware('api')
-                ->namespace($this->namespace)
-                ->group(base_path('routes/api.php'));
+        $router->prefix('api')
+               ->middleware('api')
+               ->namespace($this->namespace)
+               ->group(base_path('routes/api.php'));
     }
 }


### PR DESCRIPTION
somehow I added an extra space before the API route lines. oops. formatting for consistency.