### PR TITLE
Activates the first tab only if there is one

### DIFF
--- a/resources/assets/js/mixins/tab-state.js
+++ b/resources/assets/js/mixins/tab-state.js
@@ -70,9 +70,11 @@ module.exports = {
         activateFirstTab() {
             const tab = $(`${this.pushStateSelector} a[data-toggle="tab"]`).first();
 
-            tab.tab('show');
+            if (tab.length) {
+                tab.tab('show');
 
-            this.broadcastTabChange(tab.attr('href').substring(1));
+                this.broadcastTabChange(tab.attr('href').substring(1));
+            }
         },
 
 


### PR DESCRIPTION
This PR addresses a fix on the method `activateFirstTab`. The method tries to activate the first tab, even when there no first tab to activate.