### PR TITLE
Update DashboardController.php

### DIFF
--- a/src/Http/Controllers/Settings/Teams/DashboardController.php
+++ b/src/Http/Controllers/Settings/Teams/DashboardController.php
@@ -27,6 +27,8 @@ class DashboardController extends Controller
     public function show(Request $request, $team)
     {
         abort_unless($request->user()->onTeam($team), 404);
+        
+        $team = Spark::interact(TeamRepository::class.'@find', [$team]);
 
         return view('spark::settings.teams.team-settings', compact('team'));
     }


### PR DESCRIPTION
The view returned from the show function expects the variable sent to be an object containing the team data. As it is now, the code returns a variable (string) that is the ID of the team. This corrects that error by calling the find interaction.