### PR TITLE
Update TeamController.php

### DIFF
--- a/src/Http/Controllers/TeamController.php
+++ b/src/Http/Controllers/TeamController.php
@@ -79,6 +79,8 @@ class TeamController extends Controller
     {
         abort_unless($request->user()->onTeam($team), 404);
 
+        $team = Spark::interact(TeamRepository::class.'@find', [$team]);        
+
         $request->user()->switchToTeam($team);
 
         return back();


### PR DESCRIPTION
The switchCurrentTeam function is sent the ID of a team and sends that ID to the $request->user()->switchToTeam($team); function. However, this function expects an object of team properties. The result is an error when you try to switch teams. Adding in the line to find the team from the ID solves this problem.