### PR TITLE
Use 'url' helper for non-relative links to allow for non-root placement of application.

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -10,7 +10,7 @@
                 <div class="card-body">
                     @include('spark::shared.errors')
 
-                    <form role="form" method="POST" action="/login">
+                    <form role="form" method="POST" action="{{ url('/login') }}">
                         {{ csrf_field() }}
 
                         <!-- E-Mail Address -->

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,7 +13,7 @@
     <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 
     <!-- CSS -->
-    <link href="{{ mix(Spark::usesRightToLeftTheme() ? 'css/app-rtl.css' : 'css/app.css') }}" rel="stylesheet">
+    <link href="{{ url(mix(Spark::usesRightToLeftTheme() ? 'css/app-rtl.css' : 'css/app.css')) }}" rel="stylesheet">
 
     <!-- Scripts -->
     @yield('scripts', '')
@@ -48,7 +48,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="{{ mix('js/app.js') }}"></script>
-    <script src="/js/sweetalert.min.js"></script>
+    <script src="{{ url(mix('js/app.js')) }}"></script>
+    <script src="{{ url('/js/sweetalert.min.js') }}"></script>
 </body>
 </html>

--- a/resources/views/nav/brand.blade.php
+++ b/resources/views/nav/brand.blade.php
@@ -1,4 +1,4 @@
-<a class="navbar-brand" href="/home">
+<a class="navbar-brand" href="{{ url('/home') }}">
     <svg class="h-37 w-auto" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 43" xmlns:xlink="http://www.w3.org/1999/xlink">
         <defs>
             <path id="a" d="M22 2.5c4-3.8 6.7-2.4 6 3.2l-1.5 10h4.2c5.5 0 6.7 3.2 2.6 7L14 40.7c-4 3.7-6.7 2.3-6-3.3l1.5-10H5.3c-5.5 0-6.7-3-2.6-7L22 2.4z"

--- a/resources/views/nav/developer.blade.php
+++ b/resources/views/nav/developer.blade.php
@@ -1,7 +1,7 @@
 <h6 class="dropdown-header">{{__('Developer')}}</h6>
 
 <!-- Kiosk -->
-<a class="dropdown-item" href="/spark/kiosk">
+<a class="dropdown-item" href="{{ url('/spark/kiosk') }}">
     <i class="fa fa-fw text-left fa-btn fa-fort-awesome"></i> {{__('Kiosk')}}
 </a>
 

--- a/resources/views/nav/guest.blade.php
+++ b/resources/views/nav/guest.blade.php
@@ -33,10 +33,10 @@
         <div id="navbarSupportedContent" class="collapse navbar-collapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="/login">{{__('Login')}}</a>
+                    <a class="nav-link" href="{{ url('/login') }}">{{__('Login')}}</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/register">{{__('Register')}}</a>
+                    <a class="nav-link" href="{{ url('/register') }}">{{__('Register')}}</a>
                 </li>
             </ul>
         </div>

--- a/resources/views/nav/subscriptions.blade.php
+++ b/resources/views/nav/subscriptions.blade.php
@@ -2,7 +2,7 @@
     <!-- Trial Reminder -->
     <h6 class="dropdown-header">{{__('Trial')}}</h6>
 
-    <a class="dropdown-item" href="/settings#/subscription">
+    <a class="dropdown-item" href="{{ url('/settings#/subscription') }}">
         <i class="fa fa-fw text-left fa-btn fa-shopping-bag"></i> {{__('Subscribe')}}
     </a>
 
@@ -13,7 +13,7 @@
     <!-- Team Trial Reminder -->
     <h6 class="dropdown-header">{{__('teams.team_trial')}}</h6>
 
-    <a class="dropdown-item" href="/settings/{{ Spark::teamsPrefix() }}/{{ Auth::user()->currentTeam()->id }}#/subscription">
+    <a class="dropdown-item" href="{{ url('/settings/' . Spark::teamsPrefix() . '/' . Auth::user()->currentTeam()->id . '#/subscription') }}">
         <i class="fa fa-fw text-left fa-btn fa-shopping-bag"></i> {{__('Subscribe')}}
     </a>
 

--- a/resources/views/nav/user.blade.php
+++ b/resources/views/nav/user.blade.php
@@ -55,7 +55,7 @@
                                 <h6 class="dropdown-header">{{__('Impersonation')}}</h6>
 
                                 <!-- Stop Impersonating -->
-                                <a class="dropdown-item" href="/spark/kiosk/users/stop-impersonating">
+                                <a class="dropdown-item" href="{{ url('/spark/kiosk/users/stop-impersonating') }}">
                                     <i class="fa fa-fw text-left fa-btn fa-user-secret"></i> {{__('Back To My Account')}}
                                 </a>
 
@@ -74,7 +74,7 @@
                             <h6 class="dropdown-header">{{__('Settings')}}</h6>
 
                             <!-- Your Settings -->
-                            <a class="dropdown-item" href="/settings">
+                            <a class="dropdown-item" href="{{ url('/settings') }}">
                                 <i class="fa fa-fw text-left fa-btn fa-cog"></i> {{__('Your Settings')}}
                             </a>
 
@@ -91,7 +91,7 @@
                             @endif
 
                             <!-- Logout -->
-                            <a class="dropdown-item" href="/logout">
+                            <a class="dropdown-item" href="{{ url('/logout') }}">
                                 <i class="fa fa-fw text-left fa-btn fa-sign-out"></i> {{__('Logout')}}
                             </a>
                         </div>


### PR DESCRIPTION
_Suggestion PR, not complete yet._ 

This came up as I tried to put a project on a non-root web folder for testing and using a base URL. These are the main ones that cropped up and caused the main pages to not load / look like junk.

If there is a reason to avoid using 'url' helper inside Spark or if `URL::to(..)` is the better option, I'd like to know.

Depending on current project, I might do another round to find other URLs that should use the helper. 