### PR TITLE
Update Doc Blocks in ManagesApiOptions.php

### DIFF
--- a/src/Configuration/ManagesApiOptions.php
+++ b/src/Configuration/ManagesApiOptions.php
@@ -69,8 +69,7 @@ trait ManagesApiOptions
     /**
      * Get the default token abilities to "check" in the UI.
      *
-     * @param  array  $defaults
-     * @return array|null
+     * @return array
      */
     public static function tokenDefaults()
     {
@@ -81,7 +80,6 @@ trait ManagesApiOptions
      * Set the default token abilities to "check" in the UI.
      *
      * @param  array  $defaults
-     * @return array|null
      */
     public static function byDefaultTokensCan(array $defaults)
     {


### PR DESCRIPTION
Remove unused parameter doc and return doc.  

`tokenDefaults` cannot return `null`.