### PR TITLE
remove `.invalid-feedback` class

### DIFF
--- a/resources/assets/sass/spark.scss
+++ b/resources/assets/sass/spark.scss
@@ -36,10 +36,6 @@ pre {
   border-radius: 4px;
 }
 
-.invalid-feedback{
-  display: block;
-}
-
 .plan-feature-list{
   list-style: none;
 }


### PR DESCRIPTION
this class overrides the default BS4 behavior of being hidden until the form is validated, and then becoming a block level element.  prior to removing this code, there is a lot of extra space between inputs because the error div is taking up a little bit of height.