### PR TITLE
use production vue in production

### DIFF
--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -29,7 +29,7 @@ mix
                 'node_modules'
             ],
             alias: {
-                'vue$': 'vue/dist/vue.js'
+                'vue$': mix.inProduction() ? 'vue/dist/vue.min' : 'vue/dist/vue.js'
             }
         }
     });


### PR DESCRIPTION
When assets are built for production, use the production version of vue.  Otherwise, use the development version.