### PR TITLE
update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.1.3",
         "erusev/parsedown": "~1.0",
         "firebase/php-jwt": "~3.0|~4.0",
         "guzzlehttp/guzzle": "~6.0",
@@ -18,8 +18,8 @@
         "intervention/image": "^2.3"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~5.0",
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^7.0",
         "mpociot/vat-calculator": "^1.6"
     },
     "autoload": {


### PR DESCRIPTION
spark-aurelius requires Laravel Framework 5.6+, so common dependencies between the two can be updated.

This leaves dependencies that are not common alone.  The net result is no modification to the installed composer packages.  This would be a documentation only update.