### PR TITLE
update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5.9",
         "erusev/parsedown": "~1.0",
-        "firebase/php-jwt": "~3.0|~4.0",
+        "firebase/php-jwt": "~4.0|~5.0",
         "guzzlehttp/guzzle": "~6.0",
         "ramsey/uuid": "^3.1",
         "intervention/image": "^2.3"


### PR DESCRIPTION
Allow the usage of JWT@5.0, drop 3.0 for security.  4.0 would have been installed by anyone updating to spark-aurelius