### PR TITLE
Use vendor name, not product, as fallback sender name when showing notification.

### DIFF
--- a/resources/views/modals/notifications.blade.php
+++ b/resources/views/modals/notifications.blade.php
@@ -55,7 +55,7 @@
                                             </span>
 
                                             <span v-else>
-                                                {{ Spark::product() }}
+                                                {{ Spark::vendor() }}
                                             </span>
                                         </p>
 

--- a/src/Configuration/ManagesAppDetails.php
+++ b/src/Configuration/ManagesAppDetails.php
@@ -32,6 +32,16 @@ trait ManagesAppDetails
     }
 
     /**
+     * Get the vendor name from the application information.
+     *
+     * @return string
+     */
+    public static function vendor()
+    {
+        return static::$details['vendor'];
+    }
+
+    /**
      * Get the product name from the application information.
      *
      * @return string


### PR DESCRIPTION
The use of product instead of vendor here in notification creator fallback seemed odd to me, more so as it bit me on the first system-generated notification... I had a very, _very_ thorough product description that filled the notification area, and with 7 notifications triggered at the same time, it looked mostly like lorem ipsum drowning what little real information was in there. 

Adding PR mostly as a _"hey, anyone else think this was odd?"_ nod and future _"I also ran into this"_ dokumentation purposes. Feel free to close with reckless abandon!