### PR TITLE
update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         "erusev/parsedown": "~1.0",
         "firebase/php-jwt": "~4.0|~5.0",
         "guzzlehttp/guzzle": "~6.0",
-        "ramsey/uuid": "^3.1",
-        "intervention/image": "^2.3"
+        "intervention/image": "^2.3",
+        "mpociot/vat-calculator": "^1.6",
+        "ramsey/uuid": "^3.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0",
-        "mpociot/vat-calculator": "^1.6"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`"mpociot/vat-calculator": "^1.6"` is used in the `App\Billable` trait but is included in the development dependencies.

For production deployments, `composer install --no-dev`, this dependency may not be installed.