### PR TITLE
Consider fallback local in scriptVariables()

### DIFF
--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -18,7 +18,7 @@ trait ProvidesScriptVariables
     public static function scriptVariables()
     {
         return [
-            'translations' => (array) json_decode(file_get_contents(resource_path('lang/'.app()->getLocale().'.json'))) + ['teams.team' => trans('teams.team'), 'teams.member' => trans('teams.member')],
+            'translations' => (array) json_decode(file_get_contents(is_readable(resource_path('lang/'.app()->getLocale().'.json')) ? resource_path('lang/'.app()->getLocale().'.json') : resource_path('lang/'.app('translator')->getFallback().'.json'))) + ['teams.team' => trans('teams.team'), 'teams.member' => trans('teams.member')],
             'braintreeMerchantId' => config('services.braintree.merchant_id'),
             'braintreeToken' => Spark::billsUsingBraintree() ? BraintreeClientToken::generate() : null,
             'cardUpFront' => Spark::needsCardUpFront(),


### PR DESCRIPTION
On first install, if Spark is configured on a non-existant locale but fallback as "en", an error 500 is emitted because `Laravel\Spark\Configuration\ProvidesScriptVariables::scriptVariables()` doesn't fallback