### PR TITLE
update HTTP global middleware stack

### DIFF
--- a/install-stubs/app/Http/Kernel.php
+++ b/install-stubs/app/Http/Kernel.php
@@ -15,6 +15,10 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\TrustProxies::class,
     ];
 
     /**


### PR DESCRIPTION
update the http global middleware stack to be in sync with `laravel/laravel`

When installing Spark, it uses the 'install-stubs' rather than the `laravel/laravel` files in some cases, and this one was not kept up to date appropriately.  I think the assumption when installing spark is we get normal Laravel behavior *plus* the additional Spark changes.  Therefore it is not immediately obvious to a Spark user that these middlewares are missing.

In my case, I was developing an App for a month before running into a strange issue where empty string input values weren't coming across as `null`s, and that led me to this bug.

Is there a way we can prevent this from happening in the future?