### PR TITLE
Add uses2FA to script variables. Display 2FA status on Team Members view.

### DIFF
--- a/resources/views/settings/teams/team-members.blade.php
+++ b/resources/views/settings/teams/team-members.blade.php
@@ -11,6 +11,7 @@
                         <th class="th-fit"></th>
                         <th>{{__('Name')}}</th>
                         <th v-if="roles.length > 1">{{__('Role')}}</th>
+                        <th v-if="spark.uses2FA">2FA</th>
                         <th>&nbsp;</th>
                     </thead>
 
@@ -35,6 +36,11 @@
                             <!-- Role -->
                             <td v-if="roles.length > 0">
                                 @{{ teamMemberRole(member) }}
+                            </td>
+
+                            <!-- 2FA -->
+                            <td v-if="spark.uses2FA">
+                                @{{ member.uses_two_factor_auth ? 'Yes' : 'No' }}
                             </td>
 
                             <td class="td-fit">

--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -34,6 +34,7 @@ trait ProvidesScriptVariables
             'teamsPrefix' => Spark::teamsPrefix(),
             'userId' => Auth::id(),
             'usesApi' => Spark::usesApi(),
+            'uses2FA' => Spark::usesTwoFactorAuth(),
             'usesBraintree' => Spark::billsUsingBraintree(),
             'usesTeams' => Spark::usesTeams(),
             'usesStripe' => Spark::billsUsingStripe(),


### PR DESCRIPTION
This change adds 'uses2FA' to the Spark object:

<img width="163" alt="screen shot 2018-06-02 at 2 33 23 pm" src="https://user-images.githubusercontent.com/943942/40871000-f8bd49ce-6672-11e8-9d3e-3d49b0afedc6.png">

And it adds an extra column on the Team Members view to display that member's 2FA status:

<img width="854" alt="screen shot 2018-06-02 at 2 37 20 pm" src="https://user-images.githubusercontent.com/943942/40871008-14063542-6673-11e8-8d64-b0c324114688.png">

Many organisations have an internal policy that Two Factor Authentication must be enabled on applications that their employees use. This change allows them to verify that.