### PR TITLE
When selecting a plan, accept any clicks on the plan name.

### DIFF
--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -46,9 +46,9 @@
             <tbody>
                 <tr v-for="plan in paidPlansForActiveInterval">
                     <!-- Plan Name -->
-                    <td>
+                    <td @click="selectPlan(plan)">
                         <div class="d-flex align-items-center">
-                            <i class="radio-select mr-2" @click="selectPlan(plan)"
+                            <i class="radio-select mr-2"
                                :class="{'radio-select-selected': selectedPlan == plan, invisible: form.busy}"></i>
                             @{{ plan.name }}
                         </div>

--- a/resources/views/settings/subscription/update-subscription.blade.php
+++ b/resources/views/settings/subscription/update-subscription.blade.php
@@ -60,9 +60,9 @@
                     <tbody>
                         <tr v-for="plan in plansForActiveInterval">
                             <!-- Plan Name -->
-                            <td>
+                            <td @click="!isActivePlan(plan) ? confirmPlanUpdate(plan) : 0">
                                 <div class="d-flex align-items-center">
-                                    <i class="radio-select mr-2" @click="!isActivePlan(plan) ? confirmPlanUpdate(plan) : 0"
+                                    <i class="radio-select mr-2"
                                     :class="{'radio-select-selected': isActivePlan(plan), invisible: selectingPlan}"></i>
                                     @{{ plan.name }}
                                 </div>


### PR DESCRIPTION
This change modifies the plan selection to accept any clicks to the left of the <kbd>Features</kbd> button. For example, clicking on the plan name.

At the moment, it requires a click on the radio-select element.

BEFORE
![plans-before](https://user-images.githubusercontent.com/943942/40872220-cb01a360-6689-11e8-899e-05575337f18b.gif)

AFTER
![plans-after](https://user-images.githubusercontent.com/943942/40872223-cd68e672-6689-11e8-8b87-090134e869f9.gif)
