### PR TITLE
Make the Features button consistent by adding missing star icons

### DIFF
--- a/resources/views/auth/register-common.blade.php
+++ b/resources/views/auth/register-common.blade.php
@@ -84,7 +84,7 @@
                             <!-- Plan Features Button -->
                             <td>
                                 <button class="btn btn-default" @click="showPlanDetails(plan)">
-                                {{__('Features')}}
+                                    <i class="fa fa-btn fa-star-o"></i> {{__('Features')}}
                                 </button>
                             </td>
 

--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -57,7 +57,7 @@
                     <!-- Plan Features Button -->
                     <td>
                         <button class="btn btn-default" @click="showPlanDetails(plan)">
-                            {{__('Features')}}
+                            <i class="fa fa-btn fa-star-o"></i> {{__('Features')}}
                         </button>
                     </td>
 

--- a/resources/views/settings/subscription/update-subscription.blade.php
+++ b/resources/views/settings/subscription/update-subscription.blade.php
@@ -71,7 +71,7 @@
                             <!-- Plan Features Button -->
                             <td>
                                 <button class="btn btn-default" @click="showPlanDetails(plan)">
-                                    {{__('Features')}}
+                                    <i class="fa fa-btn fa-star-o"></i> {{__('Features')}}
                                 </button>
                             </td>
 


### PR DESCRIPTION
The 'Resume Subscription' page ([resume-subscription.blade.php](https://github.com/laravel/spark-aurelius/blob/7da25c733899cad33247d81ad2e3c0b5137d5bb0/resources/views/settings/subscription/resume-subscription.blade.php)) has this button:
<img width="136" alt="screen shot 2018-06-06 at 12 39 46 am" src="https://user-images.githubusercontent.com/943942/40985438-4727c906-6923-11e8-886f-e8e84ee20846.png">

However, the Register / Subscribe / Update Subscription versions of this button are missing the icon:
<img width="115" alt="screen shot 2018-06-06 at 12 39 10 am" src="https://user-images.githubusercontent.com/943942/40985480-6102092c-6923-11e8-9729-3d4455c72d7f.png">

This change adds the star icon where it is missing.

Alternatively; the star could be removed from the 'Resume Subscription' page, meaning that each of the buttons consistently do _not_ have the star icon. Happy to adjust if necessary.