### PR TITLE
Fixed ProvidesScriptVariables::getTranslations()

### DIFF
--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -53,12 +53,12 @@ trait ProvidesScriptVariables
      */
     private static function getTranslations()
     {
-        $currentTranslationFile = resource_path('lang/'.app()->getLocale().'.json');
+        $translationFile = resource_path('lang/'.app()->getLocale().'.json');
 
-        if (is_readable($currentTranslationFile)) {
-            return (array) file_get_contents($currentTranslationFile);
+        if (!is_readable($translationFile)) {
+            $translationFile = resource_path('lang/'.app('translator')->getFallback().'.json');
         }
 
-        return (array) resource_path('lang/'.app('translator')->getFallback().'.json');
+        return (array) json_decode(file_get_contents($translationFile));
     }
 }


### PR DESCRIPTION
A static method was introduced in b91d9ca. `json_decode()` was missing which broke `js` translations.