### PR TITLE
Sort countries alphabetically. Add Norway.

### DIFF
--- a/resources/assets/js/mixins/vat.js
+++ b/resources/assets/js/mixins/vat.js
@@ -5,12 +5,12 @@ module.exports = {
          */
         collectsVat(country) {
             return Spark.collectsEuropeanVat ? _.includes([
-                'BE', 'BG', 'CZ', 'DK', 'DE',
-                'EE', 'IE', 'GR', 'ES', 'FR',
-                'HR', 'IT', 'CY', 'LV', 'LT',
-                'LU', 'HU', 'MT', 'NL', 'AT',
-                'PL', 'PT', 'RO', 'SI', 'SK',
-                'FI', 'SE', 'GB',
+                'AT', 'BE', 'BG', 'CY', 'CZ',
+                'DE', 'DK', 'EE', 'ES', 'FI',
+                'FR', 'GB', 'GR', 'HR', 'HU',
+                'IE', 'IT', 'LT', 'LU', 'LV',
+                'MT', 'NL', 'PL', 'PT', 'RO',
+                'SE', 'SI', 'SK', 'NO',
             ], country) : false;
         },
 


### PR DESCRIPTION
It is much easier to reason about (and visually search through) the list of countries in alphabetical order. I've spent some time comparing the list in vat.js and in mpociot/vat-calculator package. I also looked into the "missing" EL, MC, IM, NO - the first three turned out to be correctly omitted in the list.

Norway has [Value Added Tax on Electronic Services - VOES](https://www.skatteetaten.no/en/business-and-organisation/foreign/foreign-companies/vat/voes/). I believe NO(rway) should be included on the list because of what the aforementioned website says:

> Foreign suppliers of electronic services must calculate and collect VAT on their B2C sales to Norway.

PS This is my first contribution, hence the byte-size of it. Apology for the typo in my commit message. Couldn't amend as I did the whole change using github website.