### PR TITLE
allow fluent call

### DIFF
--- a/src/Configuration/ManagesAvailablePlans.php
+++ b/src/Configuration/ManagesAvailablePlans.php
@@ -100,15 +100,17 @@ trait ManagesAvailablePlans
      * Define or retrieve an application wide promotion for new registrations.
      *
      * @param  string|null  $coupon
-     * @return string|void
+     * @return static|string
      */
     public static function promotion($coupon = null)
     {
         if (is_null($coupon)) {
             return static::$promotion;
-        } else {
-            static::$promotion = $coupon;
         }
+
+        static::$promotion = $coupon;
+
+        return new static;
     }
 
     /**


### PR DESCRIPTION
Allow fluent calls to through the promotion method, matching the trialDays and teamTrialDays methods.

Method was previously string|void, so, this should not impact existing code.