### PR TITLE
Avoid unnecessary request to Stripe.

### DIFF
--- a/src/Http/Requests/ValidatesBillingAddresses.php
+++ b/src/Http/Requests/ValidatesBillingAddresses.php
@@ -54,8 +54,7 @@ trait ValidatesBillingAddresses
      */
     protected function validateLocation($validator)
     {
-        if ($this->stripe_token &&
-            ! app(StripeService::class)->tokenIsForCountry($this->stripe_token, $this->country)) {
+        if ($this->stripe_token && $this->card_country !== $this->country) {
             $validator->errors()->add(
                 'country', __('This country does not match the origin country of your card.')
             );

--- a/src/Services/Stripe.php
+++ b/src/Services/Stripe.php
@@ -18,16 +18,4 @@ class Stripe
             $token, config('services.stripe.secret')
         )->card->country;
     }
-
-    /**
-     * Verify that the given token origin country matches the given country.
-     *
-     * @param  string  $token
-     * @param  string  $country
-     * @return bool
-     */
-    public function tokenIsForCountry($token, $country)
-    {
-        return $this->countryForToken($token) === $country;
-    }
 }


### PR DESCRIPTION
The `ValidatesBillingAddresses` trait contains a `validateBillingAddress` method, which does the following:

1. `mergeCardCountryIntoRequest` (by requesting it from Stripe)
2. add validation rules
3. add validation rule to call `validateLocation`

The last step, `validateLocation`, compares the country of the token, with the `country` in the request. But we already have `card_country`, that was fetched from the API in step 1. Hence, there's an unnecessary duplication of API call to Stripe. `validateLocation` should simply compare `$this->card_country` (just gotten from Stripe) and `$this->country` provided by the user.

Therefore, presence of `tokenIsForCountry` method is no longer required.

I noticed this problem when adding Braintree support for both collecting billing address and EU VAT tax. There were actually four calls to Braintree to check what country the card is from. This takes it down to two. I haven't yet looked into why there's two calls instead of one, but we can leave that for later. Full disclosure: Stripe is not available in Poland, so I couldn't verify this with Stripe, but I verified this code with Braintree (after my changes, not visible here).