### PR TITLE
Fix price+VAT calculation on the registration form

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -186,7 +186,7 @@ trait Billable
         $vatCalculator->setBusinessCountryCode(Spark::homeCountry());
 
         try {
-            $isValidVAT = $vatCalculator->isValidVATNumber($this->vat_id);
+            $isValidVAT = ! empty($this->vat_id) && $vatCalculator->isValidVATNumber($this->vat_id);
         } catch (VatCalculator\Exceptions\VATCheckUnavailableException $e) {
             $isValidVAT = false;
         }


### PR DESCRIPTION
This is a revisit of [this PR](https://github.com/laravel/spark/pull/719) from the spark repo - only two of the three points though.

The following change prevents showing incorrect totals to the customer (price without applicable VAT tax) before they hit the `Register` button (assuming card upfront).

1. Pass both zip and country to VAT calculator (takes into account local tax rules exceptions)
2. Validate passed `vat_id` - otherwise any non empty string causes exemption from charging the customer applicable VAT.

I changed `card_country` to `billing_country`, because `billing_country` is required (even in no card upfront scenarios) and their equality is validated anyway and it looked better right next to `billing_zip`.