### PR TITLE
City and State should not force the returned VAT tax value of 0.

### DIFF
--- a/src/Http/Controllers/TaxRateController.php
+++ b/src/Http/Controllers/TaxRateController.php
@@ -15,7 +15,7 @@ class TaxRateController extends Controller
      */
     public function calculate(Request $request)
     {
-        if (! $request->filled('city', 'state', 'zip', 'country')) {
+        if (! $request->filled('zip', 'country')) {
             return response()->json(['rate' => 0]);
         }
 


### PR DESCRIPTION
As explained in this [old PR](https://github.com/laravel/spark/pull/719) from the spark repo, **city** and **state** are not required to get the proper tax rate. You only need **zip** and **country** to get the correct VAT rate. This relates to the live price+VAT calculation on the registration page.

Whenever the billing address field values are changed, there's a request to the tax-rate endpoint. If a country is selected and zip is entered, but not the city or state, Spark incorrectly returns and shows a VAT rate of 0.

For the record, I don't agree with the old PR in terms that these fields should not be removed from the "Billing" section, as they may be required for invoicing purposes - this depends on the country of the customer. If someone wants to remove them from the form, they can do so for their own needs.