### PR TITLE
Only apply `.nav-link` styling to the `.navbar-spark` menu

### DIFF
--- a/resources/assets/sass/components/_navbar.scss
+++ b/resources/assets/sass/components/_navbar.scss
@@ -11,7 +11,7 @@
 
 // Nav
 // -------------------------------------------------------------------------- */
-.nav-link {
+.navbar-spark .nav-link {
   display: flex;
   align-items: center;
   padding-top: 5px;


### PR DESCRIPTION
The previous custom styling applied globally on `.nav-link` caused pill and tab components to be squished together.

This change will keep the `.navbar-spark` menu the same and not affect the styling of pills and tabs