### PR TITLE
Fix UI for settings menu

### DIFF
--- a/resources/assets/sass/components/_navbar.scss
+++ b/resources/assets/sass/components/_navbar.scss
@@ -11,7 +11,7 @@
 
 // Nav
 // -------------------------------------------------------------------------- */
-.navbar-spark .nav-link {
+.navbar-spark .nav-link, .spark-settings-tabs .nav-link {
   display: flex;
   align-items: center;
   padding-top: 5px;


### PR DESCRIPTION
By limiting the `.nav-link` styling to `.navbar-spark`, it removes the styling from the settings menus 

![screen shot 2018-06-30 at 4 25 26 pm](https://user-images.githubusercontent.com/4386560/42122379-49f22c3e-7c84-11e8-87f0-1b42edf91720.png)

Extending the `.nav-link` styling to `.spark-settings-tabs .nav-link` will fix the setting menus while allowing pills and tabs to keep their default styling

![screen shot 2018-06-30 at 4 35 56 pm](https://user-images.githubusercontent.com/4386560/42122383-5334899a-7c84-11e8-9c39-f833bacd11a2.png)
![screen shot 2018-06-30 at 4 36 26 pm](https://user-images.githubusercontent.com/4386560/42122385-547d7b2c-7c84-11e8-8c1b-38db7ae0e038.png)
