### PR TITLE
Makes SparkForm internal attributes non-enumerable

### DIFF
--- a/resources/assets/js/forms/form.js
+++ b/resources/assets/js/forms/form.js
@@ -2,50 +2,61 @@
  * SparkForm helper class. Used to set common properties on all forms.
  */
 window.SparkForm = function (data) {
-    var form = this;
-
     $.extend(this, data);
 
     /**
      * Create the form error helper instance.
      */
-    this.errors = new SparkFormErrors();
+    Object.defineProperties(this, {
+        errors: {
+            enumerable: false,
+            value: new SparkFormErrors,
+            writable: true
+        },
+        busy: {
+            enumerable: false,
+            value: false,
+            writable: true
+        },
+        successful: {
+            enumerable: false,
+            value: false,
+            writable: true
+        }
+    });
+};
 
+/**
+ * Start processing the form.
+ */
+window.SparkForm.startProcessing = function () {
+    this.errors.forget();
+    this.busy = true;
+    this.successful = false;
+};
+
+/**
+ * Finish processing the form.
+ */
+window.SparkForm.finishProcessing = function () {
+    this.busy = false;
+    this.successful = true;
+};
+
+/**
+ * Reset the errors and other state for the form.
+ */
+window.SparkForm.resetStatus = function () {
+    this.errors.forget();
     this.busy = false;
     this.successful = false;
-
-    /**
-     * Start processing the form.
-     */
-    this.startProcessing = function () {
-        form.errors.forget();
-        form.busy = true;
-        form.successful = false;
-    };
-
-    /**
-     * Finish processing the form.
-     */
-    this.finishProcessing = function () {
-        form.busy = false;
-        form.successful = true;
-    };
-
-    /**
-     * Reset the errors and other state for the form.
-     */
-    this.resetStatus = function () {
-        form.errors.forget();
-        form.busy = false;
-        form.successful = false;
-    };
+};
 
 
-    /**
-     * Set the errors on the form.
-     */
-    this.setErrors = function (errors) {
-        form.busy = false;
-        form.errors.set(errors);
-    };
+/**
+ * Set the errors on the form.
+ */
+window.SparkForm.setErrors = function (errors) {
+    this.busy = false;
+    this.errors.set(errors);
 };


### PR DESCRIPTION
Currently, when looping SparkForm's properties or submitting forms cause `errors`, `busy` and `successful` internal properties to be shown/submitted as well, potentially overriding a form's input.

These changes shouldn't break anything.