### PR TITLE
Fix team profile photo class in kiosk

### DIFF
--- a/resources/views/kiosk/profile.blade.php
+++ b/resources/views/kiosk/profile.blade.php
@@ -97,7 +97,7 @@
                                     <tr v-for="team in profile.owned_teams">
                                         <!-- Photo -->
                                         <td>
-                                            <img :src="team.photo_url" class="spark-team-photo">
+                                            <img :src="team.photo_url" class="spark-profile-photo">
                                         </td>
 
                                         <!-- Team Name -->


### PR DESCRIPTION
The previous class does not exist, causing the image to be displayed as a 200x200 square. Changed to the profile photo class used in other places.