### PR TITLE
Fixed "Remember Me" for 2FA login

### DIFF
--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -43,7 +43,7 @@ class LoginController extends Controller
     public function login(Request $request)
     {
         if ($request->filled('remember')) {
-            $request->session()->put('spark:auth-remember', $request->remember);
+            $request->session()->put('spark:auth:remember', $request->remember);
         }
 
         $user = Spark::user()->where('email', $request->email)->first();
@@ -87,7 +87,6 @@ class LoginController extends Controller
         // be able to get it back out and log in the correct user after verification.
         $request->session()->put([
             'spark:auth:id' => $user->id,
-            'spark:auth:remember' => $request->remember,
         ]);
 
         return redirect('login/token');


### PR DESCRIPTION
There was a typo (dash vs colon) in `spark:auth:remember`, and `$request->remember` gets unset before we ever reach line 88 where we ty to set `spark:auth:remember` to the never-existent `$request->remember`.