### PR TITLE
Removed extension from the @import directive

### DIFF
--- a/install-stubs/resources/sass/app-rtl.scss
+++ b/install-stubs/resources/sass/app-rtl.scss
@@ -1,1 +1,1 @@
-@import "app.scss";
+@import "app";


### PR DESCRIPTION
Sass doesn't need extensions to figure out which file to import. If you choose to use the Sass syntax instead of SCSS, you won't have an error after renaming `app.scss` to `app.sass`.