### PR TITLE
Update UpdateContactInformationOnStripe.php

### DIFF
--- a/src/Listeners/Profile/UpdateContactInformationOnStripe.php
+++ b/src/Listeners/Profile/UpdateContactInformationOnStripe.php
@@ -11,14 +11,23 @@ class UpdateContactInformationOnStripe
      */
     public function handle($event)
     {
-        if (! $event->user->hasBillingProvider()) {
-            return;
+        if (! $event->user->hasBillingProvider())
+        {
+            if (! $event->user->currentTeam->hasBillingProvider())
+            {
+                return;
+            }
+
+            $customer = $event->user->currentTeam->asStripeCustomer();
+        }
+        
+        else
+        {
+            $customer = $event->user->asStripeCustomer();
         }
 
-        $customer = $event->user->asStripeCustomer();
-
         $customer->email = $event->user->email;
-
+        
         $customer->save();
     }
 }


### PR DESCRIPTION
When Team Billing is being used, the 'stripe_id' database field stays empty for the User Model. When User changes their email address, the listener will not work for changing the email address for the corresponding customer in Stripe, since there is no stripe_id stored in the database. This updated listener will look for the stripe_id at the currentTeam, in order to find the matching customer in Stripe, so that email addresses can be updated.