### PR TITLE
Update UpdateContactInformationOnStripe.php

### DIFF
--- a/src/Listeners/Profile/UpdateContactInformationOnStripe.php
+++ b/src/Listeners/Profile/UpdateContactInformationOnStripe.php
@@ -11,14 +11,22 @@ class UpdateContactInformationOnStripe
      */
     public function handle($event)
     {
-        if (! $event->user->hasBillingProvider()) {
-            return;
+        if ($event->user->hasBillingProvider()) {
+            $customer = $event->user->asStripeCustomer();
+
+            $customer->email = $event->user->email;
+
+            $customer->save();
         }
+        
+        foreach ($event->user->ownedTeams as $team) {
+            if ($team->hasBillingProvider()) {
+                $customer = $team->asStripeCustomer();
 
-        $customer = $event->user->asStripeCustomer();
+                $customer->email = $event->user->email;
 
-        $customer->email = $event->user->email;
-
-        $customer->save();
+                $customer->save();
+            }
+        }
     }
 }


### PR DESCRIPTION
When a User updates its email address, this now also gets pushed to Stripe for the corresponding Teams of which the User is the owner, and are also registered as a customer in Stripe when Team Billing is being used. Includes changes as mentioned in PR #254 