### PR TITLE
Allow stripe card input placeholder translation

### DIFF
--- a/resources/assets/js/mixins/stripe.js
+++ b/resources/assets/js/mixins/stripe.js
@@ -19,7 +19,7 @@ module.exports = {
             }
 
             var card = this.stripe.elements({ 
-                    locale: _.get(window, 'Spark.locale', 'en'),
+                    locale: _.get(window, 'Spark.locale'),
                 }).create('card', {
                 hideIcon: true,
                 hidePostalCode: true,


### PR DESCRIPTION
Stripe Elements support 15 locales. By default, Elements uses the browser’s locale.  For more information checkout https://stripe.com/docs/stripe-js/reference#locale