### PR TITLE
Support email verification

### DIFF
--- a/install-stubs/app/Http/Controllers/HomeController.php
+++ b/install-stubs/app/Http/Controllers/HomeController.php
@@ -16,6 +16,8 @@ class HomeController extends Controller
         $this->middleware('auth');
 
         // $this->middleware('subscribed');
+
+        // $this->middleware('verified');
     }
 
     /**

--- a/install-stubs/app/Http/Kernel.php
+++ b/install-stubs/app/Http/Kernel.php
@@ -61,6 +61,7 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'hasTeam' => \Laravel\Spark\Http\Middleware\VerifyUserHasTeam::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'subscribed' => \Laravel\Spark\Http\Middleware\VerifyUserIsSubscribed::class,
         'teamSubscribed' => \Laravel\Spark\Http\Middleware\VerifyTeamIsSubscribed::class,

--- a/install-stubs/database/migrations/braintree/create_users_table.php
+++ b/install-stubs/database/migrations/braintree/create_users_table.php
@@ -16,6 +16,7 @@ class CreateUsersTable extends Migration
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
             $table->string('password', 60);
             $table->rememberToken();
             $table->text('photo_url')->nullable();

--- a/install-stubs/database/migrations/create_users_table.php
+++ b/install-stubs/database/migrations/create_users_table.php
@@ -16,6 +16,7 @@ class CreateUsersTable extends Migration
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
             $table->string('password', 60);
             $table->rememberToken();
             $table->text('photo_url')->nullable();

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,0 +1,25 @@
+@extends('spark::layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card card-default">
+                <div class="card-header">{{ __('Verify Your Email Address') }}</div>
+
+                <div class="card-body">
+
+                    @if (session('resent'))
+                        <div class="alert alert-success" role="alert">
+                            {{ __('A fresh verification link has been sent to your email address.') }}
+                        </div>
+                    @endif
+
+                    {{ __('Before proceeding, please check your email for a verification link.') }}
+                    {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Configuration/ManagesAppOptions.php
+++ b/src/Configuration/ManagesAppOptions.php
@@ -47,6 +47,13 @@ trait ManagesAppOptions
     public static $usesRightToLeftTheme = false;
 
     /**
+     * Indicates that the user must verify email to have access.
+     *
+     * @var bool
+     */
+    public static $mustVerifyEmail = false;
+
+    /**
      * Where to redirect users after authentication.
      *
      * @return string
@@ -187,5 +194,25 @@ trait ManagesAppOptions
     public static function useRightToLeftTheme()
     {
         static::$usesRightToLeftTheme = true;
+    }
+
+    /**
+     * Determine if the user must verify his email.
+     *
+     * @return bool
+     */
+    public static function mustVerifyEmail()
+    {
+        return static::$mustVerifyEmail;
+    }
+
+    /**
+     * Indication that the user must verify his email.
+     *
+     * @return void
+     */
+    public static function ensureEmailIsVerified()
+    {
+        static::$mustVerifyEmail = true;
     }
 }

--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -6,6 +6,7 @@ use Laravel\Spark\Spark;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Spark\Events\Auth\UserRegistered;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Laravel\Spark\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\RedirectsUsers;
 use Laravel\Spark\Contracts\Interactions\Auth\Register;
@@ -60,6 +61,10 @@ class RegisterController extends Controller
         ));
 
         event(new UserRegistered($user));
+
+        if ($user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail()) {
+            $user->sendEmailVerificationNotification();
+        }
 
         return response()->json([
             'redirect' => $this->redirectPath()

--- a/src/Http/Controllers/Auth/VerificationController.php
+++ b/src/Http/Controllers/Auth/VerificationController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Spark\Http\Controllers\Auth;
+
+use Illuminate\Http\Request;
+use Illuminate\Foundation\Auth\VerifiesEmails;
+use Laravel\Spark\Http\Controllers\Controller;
+
+class VerificationController extends Controller
+{
+    use VerifiesEmails;
+
+    /**
+     * Where to redirect users after verification.
+     *
+     * @var string
+     */
+    protected $redirectTo = '/home';
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('signed')->only('verify');
+        $this->middleware('throttle:6,1')->only('verify', 'resend');
+    }
+
+    /**
+     * Show the email verification notice.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Request $request)
+    {
+        return $request->user()->hasVerifiedEmail()
+                        ? redirect($this->redirectPath())
+                        : view('spark::auth.verify');
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,9 +1,6 @@
 <?php
 
-$router->group(['middleware' => 'web'], function ($router) {
-    // Terms Of Service...
-    $router->get('/terms', 'TermsController@show')->name('terms');
-
+$router->group(['middleware' => Laravel\Spark\Spark::mustVerifyEmail() ? ['web', 'verified'] : 'web'], function ($router) {
     // Customer Support...
     $router->post('/support/email', 'SupportController@sendEmail');
 
@@ -156,6 +153,11 @@ $router->group(['middleware' => 'web'], function ($router) {
     // Kiosk Impersonation...
     $router->get('/spark/kiosk/users/impersonate/{id}', 'Kiosk\ImpersonationController@impersonate');
     $router->get('/spark/kiosk/users/stop-impersonating', 'Kiosk\ImpersonationController@stopImpersonating');
+});
+
+$router->group(['middleware' => 'web'], function ($router) {
+    // Terms Of Service...
+    $router->get('/terms', 'TermsController@show')->name('terms');
 
     // Authentication...
     $router->get('/login', 'Auth\LoginController@showLoginForm')->name('login');
@@ -178,6 +180,11 @@ $router->group(['middleware' => 'web'], function ($router) {
     $router->get('/password/reset/{token?}', 'Auth\PasswordController@showResetForm')->name('password.reset');
     $router->post('/password/email', 'Auth\PasswordController@sendResetLinkEmail');
     $router->post('/password/reset', 'Auth\PasswordController@reset');
+
+    // Email Verification
+    $router->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
+    $router->get('email/verify/{id}', 'Auth\VerificationController@verify')->name('verification.verify');
+    $router->get('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
 });
 
 // Tax Rates...


### PR DESCRIPTION
To support email verification user need to implement the `Illuminate\Contracts\Auth\MustVerifyEmail` interface on the User model, this will send an email to the newly registered account asking for verification.

If the user wishes to block access to spark for non-verified emails he need to use `Spark::ensureEmailIsVerified()`, this will add the `verified` middleware to all Spark routes.