### PR TITLE
use @stack instead of @yield

### DIFF
--- a/resources/views/auth/register-braintree.blade.php
+++ b/resources/views/auth/register-braintree.blade.php
@@ -1,8 +1,8 @@
 @extends('spark::layouts.app')
 
-@section('scripts')
+@push('scripts')
     <script src="https://js.braintreegateway.com/v2/braintree.js"></script>
-@endsection
+@endpush
 
 @section('content')
 <spark-register-braintree inline-template>

--- a/resources/views/auth/register-stripe.blade.php
+++ b/resources/views/auth/register-stripe.blade.php
@@ -1,8 +1,8 @@
 @extends('spark::layouts.app')
 
-@section('scripts')
+@push('scripts')
     <script src="https://js.stripe.com/v3/"></script>
-@endsection
+@endpush
 
 @section('content')
 <spark-register-stripe inline-template>

--- a/resources/views/kiosk.blade.php
+++ b/resources/views/kiosk.blade.php
@@ -1,9 +1,9 @@
 @extends('spark::layouts.app')
 
-@section('scripts')
+@push('scripts')
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.min.js"></script>
-@endsection
+@endpush
 
 @section('content')
 <spark-kiosk :user="user" inline-template>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,7 +16,7 @@
     <link href="{{ mix(Spark::usesRightToLeftTheme() ? 'css/app-rtl.css' : 'css/app.css') }}" rel="stylesheet">
 
     <!-- Scripts -->
-    @yield('scripts', '')
+    @stack('scripts')
 
     <!-- Global Spark Object -->
     <script>

--- a/resources/views/layouts/blade/app.blade.php
+++ b/resources/views/layouts/blade/app.blade.php
@@ -16,7 +16,7 @@
     <link href="{{ mix(Spark::usesRightToLeftTheme() ? 'css/app-rtl.css' : 'css/app.css') }}" rel="stylesheet">
 
     <!-- Scripts -->
-    @yield('scripts', '')
+    @stack('scripts')
 
     <!-- Global Spark Object -->
     <script>

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -1,12 +1,12 @@
 @extends('spark::layouts.app')
 
-@section('scripts')
+@push('scripts')
     @if (Spark::billsUsingStripe())
         <script src="https://js.stripe.com/v3/"></script>
     @else
         <script src="https://js.braintreegateway.com/v2/braintree.js"></script>
     @endif
-@endsection
+@endpush
 
 @section('content')
     <spark-settings :user="user" :teams="teams" inline-template>

--- a/resources/views/settings/teams/team-settings.blade.php
+++ b/resources/views/settings/teams/team-settings.blade.php
@@ -1,12 +1,12 @@
 @extends('spark::layouts.app')
 
-@section('scripts')
+@push('scripts')
     @if (Spark::billsUsingStripe())
         <script src="https://js.stripe.com/v3/"></script>
     @else
         <script src="https://js.braintreegateway.com/v2/braintree.js"></script>
     @endif
-@endsection
+@endpush
 
 @section('content')
 <spark-team-settings :user="user" :team-id="{{ $team->id }}" inline-template>


### PR DESCRIPTION
For scripts, it makes more sense to use stacks, because this allows us to append or prepend to the stack from other view files. Yields force an all or nothing, and will overwrite any other sections of the same name.

should also help developers try and avoid editing Spark templates, and give them a place to hook in with their own custom scripts.

- update `@yield` to `@stack`
- remove empty string second parameter, as that's already the default in the method
- update `@section` to `@push`