### PR TITLE
[8.0] Cashier compatibility

### DIFF
--- a/src/Interactions/Settings/PaymentMethod/UpdateStripePaymentMethod.php
+++ b/src/Interactions/Settings/PaymentMethod/UpdateStripePaymentMethod.php
@@ -28,7 +28,7 @@ class UpdateStripePaymentMethod implements UpdatePaymentMethod
         // If a billable entity already has a Stripe ID, we will just update their card then
         // return, but if entities do not have a Stripe ID, we'll need to create a Stripe
         // customer with this given token so that they really exist in Stripe's system.
-        if (!$billable->stripe_id) {
+        if (! $billable->stripe_id) {
             $billable->createAsStripeCustomer();
         }
 


### PR DESCRIPTION
due to this PR on cashier

https://github.com/laravel/cashier/pull/588/files

the `createAsStripeCustomer()` method no longer takes `$token` as the first parameter. Therefore, we must manually call the `updateCard()` method to update the card with the new Stripe Token.

I believe this needs to go to 'master' because if we left it on v7, existing users could not stick on Cashier v7