### PR TITLE
Fixed CallsInteractions::interact(), now correctly matches a class name as interaction

### DIFF
--- a/src/Configuration/CallsInteractions.php
+++ b/src/Configuration/CallsInteractions.php
@@ -52,6 +52,10 @@ trait CallsInteractions
             return static::callSwappedInteraction($base.'@'.$method, $parameters, $class);
         }
 
+        if (isset(static::$interactions[$base])) {
+            return static::callSwappedInteraction($base, $parameters, $class);
+        }
+
         return call_user_func_array([app($class), $method], $parameters);
     }
 


### PR DESCRIPTION
Previously, swapping an interaction without specifying the method wouldn't work, as "CallsInteractions::interact()" was always looking for registered interactions with method.

If you swapped a method using only the class name (`Spark::swap('EnableTwoFactorAuth', …)` for instance), `interact()` will look for `EnableTwoFactorAuth@handle` in existing interactions, which doesn't exist.