### PR TITLE
[8.0] update webpack stub

### DIFF
--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -21,7 +21,7 @@ mix
     .then(() => {
         exec('node_modules/rtlcss/bin/rtlcss.js public/css/app-rtl.css ./public/css/app-rtl.css');
     })
-    .version(['public/css/app-rtl.css'])
+    .version()
     .webpackConfig({
         resolve: {
             modules: [


### PR DESCRIPTION
I'm not sure what the intent of including the RTL css file in here was. Maybe an older version of Mix behaved differently?

Whether I compile with or without this code, I get the same output.  According to the [documentation](https://laravel.com/docs/5.8/mix#versioning-and-cache-busting):

> The version method will automatically append a unique hash to the filenames of all compiled files, allowing for more convenient cache busting

Since the RTL file is compiled, it is automatically versioned.

Also, on a side note since this repo doesn't have Issues enabled, can we get the default branch updated to 8.0?