### PR TITLE
[8.0] Only compile RTL and version in production

### DIFF
--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -17,11 +17,6 @@ mix
     .sass('resources/sass/app.scss', 'public/css')
     .js('resources/js/app.js', 'public/js')
     .copy('node_modules/sweetalert/dist/sweetalert.min.js', 'public/js/sweetalert.min.js')
-    .sass('resources/sass/app-rtl.scss', 'public/css')
-    .then(() => {
-        exec('node_modules/rtlcss/bin/rtlcss.js public/css/app-rtl.css ./public/css/app-rtl.css');
-    })
-    .version()
     .webpackConfig({
         resolve: {
             modules: [
@@ -33,3 +28,13 @@ mix
             }
         }
     });
+
+if (mix.inProduction()) {
+
+    mix
+        .sass('resources/sass/app-rtl.scss', 'public/css')
+        .then(() => {
+            exec('node_modules/rtlcss/bin/rtlcss.js public/css/app-rtl.css ./public/css/app-rtl.css');
+        })
+        .version();
+}


### PR DESCRIPTION
in local development, there is a lot of iteration which leads to a lot of code compilation. this can often be a timely operation, which can be a point of frustration.

by moving this code to run only in production, I have seen reductions of 5 to 10 seconds in compilations.

i realize i am being a little opinionated here by making LTR the default, but I believe I'm covering the higher use case. Since this is just a stub, users can make adjustments as needed.