### PR TITLE
Update notifications.blade.php

### DIFF
--- a/resources/views/modals/notifications.blade.php
+++ b/resources/views/modals/notifications.blade.php
@@ -23,7 +23,7 @@
                     <div class="modal-body">
                         <!-- Informational Messages -->
                         <div class="notification-container" v-if="loadingNotifications">
-                            <i class="fa fa-btn fa-spinner fa-spin"></i> {{__('Loading Notifications')}}
+                            <div><i class="fa fa-btn fa-spinner fa-spin"></i> {{__('Loading Notifications')}}</div>
                         </div>
 
                         <div class="notification-container" v-if=" ! loadingNotifications && activeNotifications.length == 0">


### PR DESCRIPTION
if a user has upgraded to FontAwesome 5, the notifications break. due to something with how FA5 replaces the `<i>` tags with `<svg>`s and the Vue conditional, you end up with multiple SVGs and the notifications don't load correctly.

wrapping the icon and the words in a `<div>` fixes it, although I'm not exactly sure why.