### PR TITLE
remove alert from announcement

### DIFF
--- a/resources/views/kiosk/announcements.blade.php
+++ b/resources/views/kiosk/announcements.blade.php
@@ -4,9 +4,6 @@
             <div class="card-header">{{__('Create Announcement')}}</div>
 
             <div class="card-body">
-                <div class="alert alert-info">
-                    {{__('Announcements you create here will be sent to the "Product Announcements" section of the notifications modal window, informing your users about new features and improvements to your application.')}}
-                </div>
 
                 <form role="form">
                     <!-- Announcement -->


### PR DESCRIPTION
this is definitely an opinionated change, but I don't feel the alert adds anything to the page, it just gets in the way.

Spark documentation clearly states what Announcements do, which I think is good enough.