### PR TITLE
remove unused classes

### DIFF
--- a/resources/views/auth/register-common.blade.php
+++ b/resources/views/auth/register-common.blade.php
@@ -27,7 +27,7 @@
     <div class="col-lg-8">
         <div class="card card-default">
             <div class="card-header">
-                <div class="float-left" :class="{'btn-table-align': hasMonthlyAndYearlyPlans}">
+                <div class="float-left">
                     {{__('Subscription')}}
                 </div>
 

--- a/resources/views/kiosk/announcements.blade.php
+++ b/resources/views/kiosk/announcements.blade.php
@@ -88,14 +88,14 @@
 
                             <!-- Date -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ announcement.created_at | datetime }}
                                 </div>
                             </td>
 
                             <!-- Body -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ _.truncate(announcement.body, {length: 45}) }}
                                 </div>
                             </td>

--- a/resources/views/kiosk/metrics.blade.php
+++ b/resources/views/kiosk/metrics.blade.php
@@ -140,19 +140,19 @@
                             <tbody>
                             <tr v-if="genericTrialUsers">
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         {{__('On Generic Trial')}}
                                     </div>
                                 </td>
 
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         {{__('N/A')}}
                                     </div>
                                 </td>
 
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         @{{ genericTrialUsers }}
                                     </div>
                                 </td>
@@ -160,21 +160,21 @@
                             <tr v-for="plan in plans">
                                 <!-- Plan Name -->
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         @{{ plan.name }} (@{{ __(plan.interval) | capitalize }})
                                     </div>
                                 </td>
 
                                 <!-- Subscriber Count -->
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         @{{ plan.count }}
                                     </div>
                                 </td>
 
                                 <!-- Trialing Count -->
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         @{{ plan.trialing }}
                                     </div>
                                 </td>

--- a/resources/views/kiosk/profile.blade.php
+++ b/resources/views/kiosk/profile.blade.php
@@ -17,7 +17,7 @@
                 <div class="col-md-12">
                     <div class="card card-default">
                         <div class="card-header">
-                            <div class="btn-table-align">
+                            <div>
                                 <i class="fa fa-btn fa-times" style="cursor: pointer;" @click="showSearch"></i>
                                 @{{ profile.name }}
                             </div>
@@ -104,14 +104,14 @@
 
                                         <!-- Team Name -->
                                         <td>
-                                            <div class="btn-table-align">
+                                            <div>
                                                 @{{ team.name }}
                                             </div>
                                         </td>
 
                                         <!-- Subscription -->
                                         <td>
-                                            <div class="btn-table-align">
+                                            <div>
                                                 <span v-if="activePlan(team)">
                                                     <a :href="customerUrlOnBillingProvider(team)" target="_blank">
                                                         @{{ activePlan(team).name }} (@{{ __(activePlan(team).interval) | capitalize }})

--- a/resources/views/kiosk/users.blade.php
+++ b/resources/views/kiosk/users.blade.php
@@ -57,14 +57,14 @@
 
                                 <!-- Name -->
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         @{{ searchUser.name }}
                                     </div>
                                 </td>
 
                                 <!-- E-Mail Address -->
                                 <td>
-                                    <div class="btn-table-align">
+                                    <div>
                                         @{{ searchUser.email }}
                                     </div>
                                 </td>

--- a/resources/views/modals/notifications.blade.php
+++ b/resources/views/modals/notifications.blade.php
@@ -15,7 +15,7 @@
                             </button>
 
                             <button class="btn btn-light" :class="{'active': showingAnnouncements}" @click="showAnnouncements" style="width: 50%;">
-                                {{__('Announcements')}} <i class="fa fa-circle text-danger p-l-xs" v-if="hasUnreadAnnouncements"></i>
+                                {{__('Announcements')}} <i class="fa fa-circle text-danger" v-if="hasUnreadAnnouncements"></i>
                             </button>
                         </div>
                     </div>
@@ -27,7 +27,7 @@
                         </div>
 
                         <div class="notification-container" v-if=" ! loadingNotifications && activeNotifications.length == 0">
-                            <div class="alert alert-warning m-b-none">
+                            <div class="alert alert-warning">
                                 {{__('We don\'t have anything to show you right now! But when we do, we\'ll be sure to let you know. Talk to you soon!')}}
                             </div>
                         </div>

--- a/resources/views/modals/support.blade.php
+++ b/resources/views/modals/support.blade.php
@@ -2,7 +2,7 @@
 <div class="modal fade" id="modal-support" tabindex="-1" role="dialog">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="modal-body p-b-none">
+            <div class="modal-body">
                 <form role="form">
                     <!-- From -->
                     <div class="form-group" :class="{'is-invalid': supportForm.errors.has('from')}">
@@ -23,7 +23,7 @@
                     </div>
 
                     <!-- Message -->
-                    <div class="form-group m-b-none" :class="{'is-invalid': supportForm.errors.has('message')}">
+                    <div class="form-group" :class="{'is-invalid': supportForm.errors.has('message')}">
                         <textarea class="form-control" rows="7" v-model="supportForm.message" placeholder="{{__('Message')}}"></textarea>
 
                         <span class="invalid-feedback" v-show="supportForm.errors.has('message')">

--- a/resources/views/settings/api/tokens.blade.php
+++ b/resources/views/settings/api/tokens.blade.php
@@ -19,21 +19,21 @@
                         <tr v-for="token in tokens">
                             <!-- Name -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ token.name }}
                                 </div>
                             </td>
 
                             <!-- Created At -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ token.created_at | datetime }}
                                 </div>
                             </td>
 
                             <!-- Last Used At -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                         <span v-if="token.last_used_at">
                                             @{{ token.last_used_at | datetime }}
                                         </span>

--- a/resources/views/settings/payment-method/update-payment-method-braintree.blade.php
+++ b/resources/views/settings/payment-method/update-payment-method-braintree.blade.php
@@ -36,7 +36,7 @@
 
             <form role="form">
                 <!-- Braintree Container -->
-                <div id="braintree-payment-method-container" class="m-b-md"></div>
+                <div id="braintree-payment-method-container"></div>
 
                 <!-- Update Button -->
                 <div class="form-group">

--- a/resources/views/settings/subscription/resume-subscription.blade.php
+++ b/resources/views/settings/subscription/resume-subscription.blade.php
@@ -3,7 +3,7 @@
 
     <div class="card card-default">
         <div class="card-header">
-            <div class="float-left" :class="{'btn-table-align': hasMonthlyAndYearlyPlans}">
+            <div class="float-left">
                 {{__('Resume Subscription')}}
             </div>
 
@@ -73,7 +73,7 @@
 
                         <!-- Plan Price -->
                         <td>
-                            <div class="btn-table-align">
+                            <div>
                                 <strong class="table-plan-price">@{{ priceWithTax(plan) | currency }}</strong>
                                 @{{ plan.type == 'user' && spark.chargesUsersPerSeat ? '/ '+ spark.seatName : '' }}
                                 @{{ plan.type == 'user' && spark.chargesUsersPerTeam ? '/ '+ __('teams.team') : '' }}

--- a/resources/views/settings/subscription/subscribe-braintree.blade.php
+++ b/resources/views/settings/subscription/subscribe-braintree.blade.php
@@ -31,7 +31,7 @@
                     <!-- Braintree Container -->
                     <div class="form-group row"  v-show="form.use_existing_payment_method != '1'">
                         <div class="col-md-6 offset-md-4">
-                            <div id="braintree-subscribe-container" class="m-b-md"></div>
+                            <div id="braintree-subscribe-container"></div>
                         </div>
                     </div>
 

--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -1,6 +1,6 @@
 <div class="card card-default">
     <div class="card-header">
-        <div class="float-left" :class="{'btn-table-align': hasMonthlyAndYearlyPlans}">
+        <div class="float-left">
             {{__('Subscribe')}}
         </div>
 

--- a/resources/views/settings/subscription/update-subscription.blade.php
+++ b/resources/views/settings/subscription/update-subscription.blade.php
@@ -3,7 +3,7 @@
     <div>
         <div class="card card-default">
             <div class="card-header">
-                <div class="float-left" :class="{'btn-table-align': hasMonthlyAndYearlyPlans}">
+                <div class="float-left">
                     {{__('Update Subscription')}}
                 </div>
 
@@ -77,7 +77,7 @@
 
                             <!-- Plan Price -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     <span v-if="plan.price == 0">
                                         {{__('Free')}}
                                     </span>

--- a/resources/views/settings/teams/current-teams.blade.php
+++ b/resources/views/settings/teams/current-teams.blade.php
@@ -23,14 +23,14 @@
 
                             <!-- Team Name -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ team.name }}
                                 </div>
                             </td>
 
                             <!-- Owner Name -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     <span v-if="user.id == team.owner.id">
                                         {{__('You')}}
                                     </span>

--- a/resources/views/settings/teams/mailed-invitations.blade.php
+++ b/resources/views/settings/teams/mailed-invitations.blade.php
@@ -16,7 +16,7 @@
                         <tr class="reveal" v-for="invitation in invitations">
                             <!-- E-Mail Address -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ invitation.email }}
                                 </div>
                             </td>

--- a/resources/views/settings/teams/pending-invitations.blade.php
+++ b/resources/views/settings/teams/pending-invitations.blade.php
@@ -16,7 +16,7 @@
                         <tr v-for="invitation in invitations">
                             <!-- Team Name -->
                             <td>
-                                <div class="btn-table-align">
+                                <div>
                                     @{{ invitation.team.name }}
                                 </div>
                             </td>


### PR DESCRIPTION
they don't seem to be carryover from old Bootstrap3 classes, but also can't find them in the CSS.

- `.btn-table-align`
- `.m-b-none`
- `.p-l-xs`
- `.p-b-none`
- `.m-b-md`