### PR TITLE
Change disk storage to default

### DIFF
--- a/src/Interactions/Settings/Profile/UpdateProfilePhoto.php
+++ b/src/Interactions/Settings/Profile/UpdateProfilePhoto.php
@@ -46,10 +46,8 @@ class UpdateProfilePhoto implements Contract
 
         $path = $file->hashName('profiles');
 
-        // We will store the profile photos on the "public" disk, which is a convention
-        // for where to place assets we want to be publicly accessible. Then, we can
-        // grab the URL for the image to store with this user in the database row.
-        $disk = Storage::disk('public');
+        // We will store the profile photos on the "default" disk rather than hard-coded public disk. 
+        $disk = Storage::disk('default');
 
         $disk->put($path, $this->formatImage($file));
 


### PR DESCRIPTION
Hard-coding public into the interaction means that this doesn't follow convention with the rest of laravel, e.g. ENV settings. We just ran into an issue with a load-balanced environment because this was hard-coded to public, rather than the cloud / S3 instance we were using for file storage. 

Think it's a good option to allow people to control this. 🤷‍♂️