### PR TITLE
handle 'chart' and 'mousetrap' dependencies through package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   },
   "dependencies": {
     "bootstrap": "^4.1.1",
+    "chart.js": "^2.8.0",
     "popper.js": "^1.12",
     "jquery": "^3.2",
     "cross-env": "^5.1",
     "laravel-mix": "^2.0",
     "moment": "^2.10.6",
+    "mousetrap": "^1.6.3",
     "promise": "^7.1.1",
     "sweetalert": "^1.1.3",
     "rtlcss": "^2.2",

--- a/resources/views/kiosk.blade.php
+++ b/resources/views/kiosk.blade.php
@@ -1,10 +1,5 @@
 @extends('spark::layouts.app')
 
-@push('scripts')
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.min.js"></script>
-@endpush
-
 @section('content')
 <spark-kiosk :user="user" inline-template>
     <div class="spark-screen container">


### PR DESCRIPTION
rather than linking to the CDNs, we'll handle these dependencies with our package manager. there is a *minimal* hit in filesize, but this gives us the benefit of keeping external dependencies up to date through one mechanism.

I think there's potential to take advantage of these libraries on other pages as well.  I know, personally, mousetrap is something I install in every project.