### PR TITLE
Update spark-bootstrap.js - Fix error interceptor handle issue on cancelled requests.

### DIFF
--- a/resources/assets/js/spark-bootstrap.js
+++ b/resources/assets/js/spark-bootstrap.js
@@ -74,9 +74,9 @@ window.axios.defaults.headers.common = {
 window.axios.interceptors.response.use(function (response) {
     return response;
 }, function (error) {
-    
-    if(error.response === undefined)
+    if (error.response === undefined) {
         return Promise.reject(error);
+    }
 
     switch (error.response.status) {
         case 401:


### PR DESCRIPTION
Fix undefined property "status" in "error.response" when using axios.CancelToken on a request and request is cancelled.

"error" returns type "function" `Cancel { message: undefined }`

Example snippet:

```js

    if (typeof this.searching === 'function')
        this.searching('Search cancelled');

    // Lazily load input items
    axios.post('/spark/kiosk/team/search', this.input, {
        cancelToken: new axios.CancelToken((c) => {
            this.searching = c;
        })
    }).then(res => {
        this.teams = res.data;
    })
    .catch(err => {
        console.error('error',err.message); // Prints "Search cancelled" to console.
    });

```

https://github.com/axios/axios#cancellation