### PR TITLE
using primary keys dynamically 

### DIFF
--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -18,7 +18,7 @@ class UserRepository implements UserRepositoryContract
     public function current()
     {
         if (Auth::check()) {
-            return $this->find(Auth::user()->getKey())->shouldHaveSelfVisibility();
+            return $this->find(Auth::id())->shouldHaveSelfVisibility();
         }
     }
 


### PR DESCRIPTION
using primary keys dynamically instead of hard coding 'id' in case someone uses different column as primary key except 'id'