### PR TITLE
[8.0] Replace credentials method in PasswordController

### DIFF
--- a/src/Http/Controllers/Auth/PasswordController.php
+++ b/src/Http/Controllers/Auth/PasswordController.php
@@ -12,6 +12,7 @@ class PasswordController extends Controller
 {
     use SendsPasswordResetEmails, ResetsPasswords {
         SendsPasswordResetEmails::broker insteadof ResetsPasswords;
+        ResetsPasswords::credentials insteadof SendsPasswordResetEmails;
     }
 
     /**


### PR DESCRIPTION
This addresses an issue that was introduced by https://github.com/laravel/framework/pull/28370 which added a conflicting method name.