### PR TITLE
Update RedirectIfAuthenticated redirect value

### DIFF
--- a/install-stubs/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/install-stubs/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -3,8 +3,8 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Spark\Spark;
+use Illuminate\Support\Facades\Auth;
 
 class RedirectIfAuthenticated
 {


### PR DESCRIPTION
Middleware redirect uses static string '/home' instead of retrieving redirect value from ManagesAppOptions using Spark::afterLoginRedirect()