### PR TITLE
Update VerificationController.php

### DIFF
--- a/src/Http/Controllers/Auth/VerificationController.php
+++ b/src/Http/Controllers/Auth/VerificationController.php
@@ -5,17 +5,11 @@ namespace Laravel\Spark\Http\Controllers\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\VerifiesEmails;
 use Laravel\Spark\Http\Controllers\Controller;
+use Laravel\Spark\Spark;
 
 class VerificationController extends Controller
 {
     use VerifiesEmails;
-
-    /**
-     * Where to redirect users after verification.
-     *
-     * @var string
-     */
-    protected $redirectTo = '/home';
 
     /**
      * Create a new controller instance.
@@ -27,6 +21,8 @@ class VerificationController extends Controller
         $this->middleware('auth');
         $this->middleware('signed')->only('verify');
         $this->middleware('throttle:6,1')->only('verify', 'resend');
+
+        $this->redirectTo = Spark::afterLoginRedirect();
     }
 
     /**


### PR DESCRIPTION
Fix Verification Controller not setting `$this->redirectTo` attribute to the value of `ManagesAppOptions::$afterLoginRedirectTo`.

If default route '/home' is replaced and the path is completely removed from routing this results in landing at a 404 page where redirection to `/teams/missing` is supposed to happen after creating a fresh account and clicking verification link from the e-mail.