### PR TITLE
createAsStripeCustomer requires $token value

### DIFF
--- a/src/Interactions/Settings/PaymentMethod/UpdateStripePaymentMethod.php
+++ b/src/Interactions/Settings/PaymentMethod/UpdateStripePaymentMethod.php
@@ -26,7 +26,7 @@ class UpdateStripePaymentMethod implements UpdatePaymentMethod
         }
 
         if (! $billable->stripe_id) {
-            $billable->createAsStripeCustomer();
+            $billable->createAsStripeCustomer($data['stripe_token']);
         }
 
         $billable->updateCard($data['stripe_token']);


### PR DESCRIPTION
Currently, `$billable->createAsStripeCustomer();` fails, as `createAsStripeCustomer` requires `$token` be passed