### PR TITLE
add ability to reset form with data initially supplied

### DIFF
--- a/resources/assets/js/forms/form.js
+++ b/resources/assets/js/forms/form.js
@@ -3,7 +3,7 @@
  */
 window.SparkForm = function (data) {
     var form = this;
-    const initData = data;
+    const initialData = data;
 
     $.extend(this, data);
 
@@ -33,10 +33,10 @@ window.SparkForm = function (data) {
     };
 
     /**
-     * Reset form.
+     * Reset the form to its original state.
      */
     this.reset = function() {
-        $.extend(form, initData);
+        $.extend(form, initialData);
         form.resetStatus();
     };
 


### PR DESCRIPTION
Adds a `.reset()` method to the form object which clears any changed data back to its original state and calls the existing `resetStatus` method to clear out errors and reset any status changes.  

For use with the commonly implemented "RESET" button on a front end form.