### PR TITLE
Use big integers in migrations

### DIFF
--- a/install-stubs/database/migrations/braintree/create_subscriptions_table.php
+++ b/install-stubs/database/migrations/braintree/create_subscriptions_table.php
@@ -13,8 +13,8 @@ class CreateSubscriptionsTable extends Migration
     public function up()
     {
         Schema::create('subscriptions', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('user_id');
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->string('braintree_id');
             $table->string('braintree_plan');
@@ -25,8 +25,8 @@ class CreateSubscriptionsTable extends Migration
         });
 
         Schema::create('team_subscriptions', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('team_id');
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('team_id');
             $table->string('name');
             $table->string('braintree_id');
             $table->string('braintree_plan');

--- a/install-stubs/database/migrations/braintree/create_teams_table.php
+++ b/install-stubs/database/migrations/braintree/create_teams_table.php
@@ -13,8 +13,8 @@ class CreateTeamsTable extends Migration
     public function up()
     {
         Schema::create('teams', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('owner_id')->index();
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('owner_id')->index();
             $table->string('name');
             $table->string('slug')->nullable()->unique();
             $table->text('photo_url')->nullable();

--- a/install-stubs/database/migrations/braintree/create_users_table.php
+++ b/install-stubs/database/migrations/braintree/create_users_table.php
@@ -13,7 +13,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/install-stubs/database/migrations/create_announcements_table.php
+++ b/install-stubs/database/migrations/create_announcements_table.php
@@ -14,7 +14,7 @@ class CreateAnnouncementsTable extends Migration
     {
         Schema::create('announcements', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->unsignedInteger('user_id');
+            $table->unsignedBigInteger('user_id');
             $table->text('body');
             $table->string('action_text')->nullable();
             $table->text('action_url')->nullable();

--- a/install-stubs/database/migrations/create_api_tokens_table.php
+++ b/install-stubs/database/migrations/create_api_tokens_table.php
@@ -14,7 +14,7 @@ class CreateApiTokensTable extends Migration
     {
         Schema::create('api_tokens', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->unsignedInteger('user_id');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->string('token', 100)->unique();
             $table->text('metadata');

--- a/install-stubs/database/migrations/create_invitations_table.php
+++ b/install-stubs/database/migrations/create_invitations_table.php
@@ -14,8 +14,8 @@ class CreateInvitationsTable extends Migration
     {
         Schema::create('invitations', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->unsignedInteger('team_id')->index();
-            $table->unsignedInteger('user_id')->nullable()->index();
+            $table->unsignedBigInteger('team_id')->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('role')->nullable();
             $table->string('email');
             $table->string('token', 40)->unique();

--- a/install-stubs/database/migrations/create_invoices_table.php
+++ b/install-stubs/database/migrations/create_invoices_table.php
@@ -13,9 +13,9 @@ class CreateInvoicesTable extends Migration
     public function up()
     {
         Schema::create('invoices', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('user_id')->nullable()->index();
-            $table->unsignedInteger('team_id')->nullable()->index();
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->unsignedBigInteger('team_id')->nullable()->index();
             $table->string('provider_id');
             $table->decimal('total')->nullable();
             $table->decimal('tax')->nullable();

--- a/install-stubs/database/migrations/create_notifications_table.php
+++ b/install-stubs/database/migrations/create_notifications_table.php
@@ -14,8 +14,8 @@ class CreateNotificationsTable extends Migration
     {
         Schema::create('notifications', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->unsignedInteger('user_id');
-            $table->unsignedInteger('created_by')->nullable();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('created_by')->nullable();
             $table->string('icon', 50)->nullable();
             $table->text('body');
             $table->string('action_text')->nullable();

--- a/install-stubs/database/migrations/create_performance_indicators_table.php
+++ b/install-stubs/database/migrations/create_performance_indicators_table.php
@@ -13,7 +13,7 @@ class CreatePerformanceIndicatorsTable extends Migration
     public function up()
     {
         Schema::create('performance_indicators', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->decimal('monthly_recurring_revenue');
             $table->decimal('yearly_recurring_revenue');
             $table->decimal('daily_volume');

--- a/install-stubs/database/migrations/create_subscriptions_table.php
+++ b/install-stubs/database/migrations/create_subscriptions_table.php
@@ -13,8 +13,8 @@ class CreateSubscriptionsTable extends Migration
     public function up()
     {
         Schema::create('subscriptions', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('user_id');
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->string('stripe_id');
             $table->string('stripe_plan');
@@ -25,8 +25,8 @@ class CreateSubscriptionsTable extends Migration
         });
 
         Schema::create('team_subscriptions', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('team_id');
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('team_id');
             $table->string('name');
             $table->string('stripe_id');
             $table->string('stripe_plan');

--- a/install-stubs/database/migrations/create_team_users_table.php
+++ b/install-stubs/database/migrations/create_team_users_table.php
@@ -13,8 +13,8 @@ class CreateTeamUsersTable extends Migration
     public function up()
     {
         Schema::create('team_users', function (Blueprint $table) {
-            $table->unsignedInteger('team_id');
-            $table->unsignedInteger('user_id');
+            $table->unsignedBigInteger('team_id');
+            $table->unsignedBigInteger('user_id');
             $table->string('role', 20);
 
             $table->unique(['team_id', 'user_id']);

--- a/install-stubs/database/migrations/create_teams_table.php
+++ b/install-stubs/database/migrations/create_teams_table.php
@@ -13,8 +13,8 @@ class CreateTeamsTable extends Migration
     public function up()
     {
         Schema::create('teams', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('owner_id')->index();
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('owner_id')->index();
             $table->string('name');
             $table->string('slug')->nullable()->unique();
             $table->text('photo_url')->nullable();

--- a/install-stubs/database/migrations/create_users_table.php
+++ b/install-stubs/database/migrations/create_users_table.php
@@ -13,7 +13,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();


### PR DESCRIPTION
This updates the migrations to use `bigIncrements` and `unsignedBigInteger` - like [`laravel/laravel`](https://github.com/laravel/laravel/blob/master/database/migrations/2014_10_12_000000_create_users_table.php). Ran into this problem when creating new tables using `bigIncrements`/`unsignedBigInteger` and being unable to set up foreign keys to the existing tables.