### PR TITLE
Fix fatal error

### DIFF
--- a/src/Http/Requests/Settings/Security/EnableTwoFactorAuthRequest.php
+++ b/src/Http/Requests/Settings/Security/EnableTwoFactorAuthRequest.php
@@ -34,7 +34,7 @@ class EnableTwoFactorAuthRequest extends FormRequest
      *
      * @return array
      */
-    protected function validationData()
+    public function validationData()
     {
         if ($this->phone) {
             $this->merge(['phone' => preg_replace('/[^0-9]/', '', $this->phone)]);


### PR DESCRIPTION
The access level for the `validationData()` method needs to be consistent with its parent (`public`) to avoid this error.

```
Access level to Laravel\Spark\Http\Requests\Settings\Security\EnableTwoFactorAuthRequest::validationData() must be public (as in class Illuminate\Foundation\Http\FormRequest)
```