### PR TITLE
only version files in production

### DIFF
--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -21,7 +21,6 @@ mix
     .then(() => {
         exec('node_modules/rtlcss/bin/rtlcss.js public/css/app-rtl.css ./public/css/app-rtl.css');
     })
-    .version()
     .webpackConfig({
         resolve: {
             modules: [
@@ -33,3 +32,8 @@ mix
             }
         }
     });
+
+
+if (mix.inProduction()) {
+    mix.version();
+}


### PR DESCRIPTION
The real problem this solved for me was the versioned files breaking HMR.  I considered filling the if condition with `process.env.npm_lifecycle_event !== 'hot'` but that seemed a bit dirty to me and if I have to choose having versioned files in dev or HMR working out of the box, HMR makes more sense to me.