### PR TITLE
Only zip & country are required for getTaxRateForLocation() method

### DIFF
--- a/src/Http/Controllers/TaxRateController.php
+++ b/src/Http/Controllers/TaxRateController.php
@@ -15,7 +15,7 @@ class TaxRateController extends Controller
      */
     public function calculate(Request $request)
     {
-        if (! $request->filled('city', 'state', 'zip', 'country')) {
+        if (! $request->filled('zip', 'country')) {
             return response()->json(['rate' => 0]);
         }
 


### PR DESCRIPTION
The VAT percentage doesn't get calculated when the state or city is empty.