### PR TITLE
Pass the errors returned by the server to Vue form object

### DIFF
--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -153,7 +153,7 @@ module.exports = {
                     if (errors.response.status == 400) {
                         window.location = '/' + Spark.cashierPath + '/payment/' + errors.response.data.paymentId + '?redirect=' + this.urlForPlanRedirect;
                     } else {
-                        this.form.setErrors({form: ['Something went wrong.']});
+                        this.form.setErrors(errors.response.data.errors);
                     }
                 });
         },


### PR DESCRIPTION
When the address or city fields are empty an error message is shown as it should be.
Not sure what to do with the "Generic 500 Level Error Message" that is shown in spark/resources/views/settings/subscription/subscribe.blade.php