### PR TITLE
Update card brand cases per Stripe API docs

### DIFF
--- a/resources/assets/js/settings/payment-method/update-payment-method-stripe.js
+++ b/resources/assets/js/settings/payment-method/update-payment-method-stripe.js
@@ -154,17 +154,17 @@ module.exports = {
             }
 
             switch (this.billable.card_brand) {
-                case 'American Express':
+                case 'amex':
                     return 'fa-cc-amex';
-                case 'Diners Club':
+                case 'diners':
                     return 'fa-cc-diners-club';
-                case 'Discover':
+                case 'discover':
                     return 'fa-cc-discover';
-                case 'JCB':
+                case 'jcb':
                     return 'fa-cc-jcb';
-                case 'MasterCard':
+                case 'mastercard':
                     return 'fa-cc-mastercard';
-                case 'Visa':
+                case 'visa':
                     return 'fa-cc-visa';
                 default:
                     return 'fa-cc-stripe';


### PR DESCRIPTION
Since Spark v9 uses Cashier v10 which in turn uses Stripe's new Payment Methods API, the possible values for a billable model's `card_brand` attribute have changed. (See [https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-brand](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-brand))

Right now this switch statement is still using the old brand values from the now-unused Stripe Token API, which will always result in the card icon being set to the default case (`fa-cc-stripe`). This change updates the switch statement to use the latest brand values per Stripe's API docs.