### PR TITLE
cast invitation user ID to integer

### DIFF
--- a/src/Invitation.php
+++ b/src/Invitation.php
@@ -36,6 +36,15 @@ class Invitation extends Model
     protected $hidden = [];
 
     /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'user_id' => 'integer',
+    ];
+
+    /**
      * Get the team that owns the invitation.
      */
     public function team()


### PR DESCRIPTION
When using SQLite (during development) it would try to compare `1 === "1"` where `$request->user()->id` would be `1` and `$invitation->user_id` would be `"1"`. This would fail and invitations fail to be accepted.