### PR TITLE
Fixed change from sweet alert upgrade to fix success icon

### DIFF
--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -221,7 +221,7 @@ module.exports = {
             Swal.fire({
                 title: __('Got It!'),
                 text: __('We have received your message and will respond soon!'),
-                type: 'success',
+                icon: 'success',
                 showConfirmButton: false,
                 timer: 2000
             });


### PR DESCRIPTION
The upgrade guide for SweetAlert says that from v1 to v2 the `title` is supposed to be `icon`.

https://sweetalert.js.org/guides/#upgrading-from-1x