### PR TITLE
Wrapped image url in asset helper function in welcome view

### DIFF
--- a/install-stubs/resources/views/welcome.blade.php
+++ b/install-stubs/resources/views/welcome.blade.php
@@ -86,7 +86,7 @@
 
         <div class="flex-fill flex-center">
             <h1 class="text-center">
-                <img src="{{asset('/img/color-logo.png')}}" alt="{{__('Logo')}}" />
+                <img src="{{ asset('/img/color-logo.png') }}" alt="{{ __('Logo') }}" />
             </h1>
         </div>
     </div>


### PR DESCRIPTION
If you try to use Laravel Vapor out of the box this official Laravel Spark package does not work because this image isn't using the `asset()` helper to prefix the `ASSET_URL` environment variable so it is loaded via Cloudfront.