### PR TITLE
Wrapped sweetalert script with asset helper in app layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,6 +48,6 @@
 
     <!-- JavaScript -->
     <script src="{{ mix('js/app.js') }}"></script>
-    <script src="{{asset('/js/sweetalert.min.js')}}"></script>
+    <script src="{{ asset('/js/sweetalert.min.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
If you try to use Laravel Vapor out of the box this official Laravel Spark package does not work because this sweetalert script isn't using the `asset()` helper to prefix the `ASSET_URL` environment variable so it is loaded via Cloudfront.