### PR TITLE
Update user search to be case insensitive

### DIFF
--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -67,8 +67,8 @@ class UserRepository implements UserRepositoryContract
         }
 
         return $search->where(function ($search) use ($query) {
-            $search->where('email', 'like', $query)
-                   ->orWhere('name', 'like', $query);
+            $search->where('email', 'ilike', $query)
+                   ->orWhere('name', 'ilike', $query);
         })->get();
     }
 


### PR DESCRIPTION
The search can be a bit confusing when it isn't returning results even though there is a user. By using `ilike` I feel like it makes the search more consistent.