### PR TITLE
Fix css class and margin around error message

### DIFF
--- a/resources/views/settings/subscription/subscribe.blade.php
+++ b/resources/views/settings/subscription/subscribe.blade.php
@@ -43,9 +43,9 @@
 
                         <div class="col-md-6">
                             <div id="subscription-card-element"></div>
-                            <span class="invalid-feedback" v-show="cardForm.errors.has('card')">
+                            <p class="alert alert-danger mt-3 mb-0" v-show="cardForm.errors.has('card')">
                                 @{{ cardForm.errors.get('card') }}
-                            </span>
+                            </p>
                         </div>
                     </div>
 
@@ -70,9 +70,9 @@
                         <div class="col-md-6">
                             <input type="text" class="form-control" v-model="form.coupon" :class="{'is-invalid': form.errors.has('coupon')}">
 
-                            <span class="invalid-feedback" v-show="form.errors.has('coupon')">
-                            @{{ form.errors.get('coupon') }}
-                        </span>
+                            <p class="alert alert-danger mt-3 mb-0" v-show="form.errors.has('coupon')">
+                                @{{ form.errors.get('coupon') }}
+                            </p>
                         </div>
                     </div>
 


### PR DESCRIPTION
I was unable to get card errors to display. I noticed that .invalid-feedback has `display: none` in app-rtl.css. 

```css
.invalid-feedback{
	display:none; <-- this
	width:100%;
	margin-top:.25rem;
	font-size:80%;
	color:#dc3545
}
```

By changing to `alert alert-danger` I'm getting the error message to show. I'm a little confused about how invalid-feedback is working in other parts of the application and know I might be missing something. But I have customers who's cards are being declined and they aren't being shown an error message.

Thank you for this great project though. Definitely a big jumpstart on my project.

As a span:
![image](https://user-images.githubusercontent.com/10030196/71784757-15430d00-2fc5-11ea-8805-5e915968a415.png)

As a paragraph:
![image](https://user-images.githubusercontent.com/10030196/71784765-2b50cd80-2fc5-11ea-824a-3dc39d7fe69b.png)