### PR TITLE
Add event for inviting a guest to a team

### DIFF
--- a/src/Events/Teams/GuestInvitedToTeam.php
+++ b/src/Events/Teams/GuestInvitedToTeam.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Spark\Events\Teams;
+
+class GuestInvitedToTeam
+{
+    /**
+     * The team instance.
+     *
+     * @var \Laravel\Spark\Team
+     */
+    public $team;
+
+    /**
+     * The invitation instance.
+     *
+     * @var mixed
+     */
+    public $invitation;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Laravel\Spark\Team  $team
+     * @param  mixed  $invitation
+     * @return void
+     */
+    public function __construct($team, $invitation)
+    {
+        $this->team = $team;
+        $this->invitation = $invitation;
+    }
+}

--- a/src/Interactions/Settings/Teams/SendInvitation.php
+++ b/src/Interactions/Settings/Teams/SendInvitation.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Laravel\Spark\Invitation;
 use Illuminate\Support\Facades\Mail;
 use Laravel\Spark\Events\Teams\UserInvitedToTeam;
+use Laravel\Spark\Events\Teams\GuestInvitedToTeam;
 use Laravel\Spark\Contracts\Interactions\Settings\Teams\SendInvitation as Contract;
 
 class SendInvitation implements Contract
@@ -27,6 +28,8 @@ class SendInvitation implements Contract
 
         if ($invitedUser) {
             event(new UserInvitedToTeam($team, $invitedUser));
+        } else {
+            event(new GuestInvitedToTeam($team, $invitation));
         }
 
         return $invitation;


### PR DESCRIPTION
UserInvitedToTeam already exists, but this only fires if a user already exists in your app and is being added to an additional team. 

We need to fire events when a "new" user is being invited to the system, one that is not currently in the system.

I added the GuestInvitedToTeam event to handle this and pass the invitation object with it, as there is not a user object created yet until the person accepts the invitation.

We use this for onboarding purposes and drip campaigns for people who are invited to the app but slow to accept the invitation.

Please consider, thanks!
