### PR TITLE
Added RequirePassword middleware to Http Kernel

### DIFF
--- a/install-stubs/app/Http/Kernel.php
+++ b/install-stubs/app/Http/Kernel.php
@@ -58,6 +58,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'dev' => \Laravel\Spark\Http\Middleware\VerifyUserIsDeveloper::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'hasTeam' => \Laravel\Spark\Http\Middleware\VerifyUserHasTeam::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,


### PR DESCRIPTION
The Http Kernel stub does not yet include the RequirePassword middleware. This patch changes that, to keep in line with the framework.