### PR TITLE
Prevent logout when external resource returns 401

### DIFF
--- a/resources/assets/js/spark-bootstrap.js
+++ b/resources/assets/js/spark-bootstrap.js
@@ -74,7 +74,7 @@ window.axios.defaults.headers.common = {
 window.axios.interceptors.response.use(function (response) {
     return response;
 }, function (error) {
-    if (error.response === undefined) {
+    if (error.response === undefined || ! error.request.responseURL.startsWith(window.location.origin)) {
         return Promise.reject(error);
     }
 


### PR DESCRIPTION
When Axios makes a request to an external resource that responds with a 401 status, it will log the user out of Spark.

This change ensures that the user is only logged out when Axios receives a 401 from Spark.