### PR TITLE
Add missing table drops

### DIFF
--- a/install-stubs/database/migrations/create_spark_subscriptions_table.php
+++ b/install-stubs/database/migrations/create_spark_subscriptions_table.php
@@ -70,5 +70,7 @@ class CreateSparkSubscriptionsTable extends Migration
     {
         Schema::drop('subscriptions');
         Schema::drop('team_subscriptions');
+        Schema::drop('subscription_items');
+        Schema::drop('team_subscription_items');
     }
 }


### PR DESCRIPTION
Fix for error: SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "subscription_items" already exists.

In order to test it run: `php artisan migrate:refresh`