### PR TITLE
Use Stripe options from Cashier instead of custom config variables

### DIFF
--- a/src/Http/Controllers/Kiosk/DiscountController.php
+++ b/src/Http/Controllers/Kiosk/DiscountController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Spark\Http\Controllers\Kiosk;
 
+use Laravel\Cashier\Cashier;
 use Laravel\Spark\Spark;
 use Illuminate\Http\Request;
 use Stripe\Coupon as StripeCoupon;
@@ -45,7 +46,7 @@ class DiscountController extends Controller
             'duration' => $request->duration,
             'duration_in_months' => $request->months,
             'max_redemptions' => 1,
-        ], config('cashier.secret'));
+        ], Cashier::stripeOptions());
 
         $user->applyCoupon($coupon->id);
     }

--- a/src/Repositories/StripeCouponRepository.php
+++ b/src/Repositories/StripeCouponRepository.php
@@ -3,6 +3,7 @@
 namespace Laravel\Spark\Repositories;
 
 use Exception;
+use Laravel\Cashier\Cashier;
 use Laravel\Spark\Spark;
 use Laravel\Spark\Coupon;
 use Stripe\Coupon as StripeCoupon;
@@ -33,7 +34,7 @@ class StripeCouponRepository implements CouponRepository
     {
         try {
             $coupon = StripeCoupon::retrieve(
-                $code, ['api_key' => config('cashier.secret')]
+                $code, ['api_key' => Cashier::stripeOptions()]
             );
 
             if ($coupon && $coupon->valid) {

--- a/src/Services/Stripe.php
+++ b/src/Services/Stripe.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Spark\Services;
 
+use Laravel\Cashier\Cashier;
 use Stripe\PaymentMethod as StripePaymentMethod;
 
 class Stripe
@@ -15,7 +16,7 @@ class Stripe
     public function countryForToken($token)
     {
         return StripePaymentMethod::retrieve(
-            $token, config('cashier.secret')
+            $token, Cashier::stripeOptions()
         )->card->country;
     }
 


### PR DESCRIPTION
I found out that these calls did not specify a Stripe API version.

This PR makes sure to send all the configured options to Stripe, including the Stripe api version.