### PR TITLE
WIP: Get current team when updating the user

### DIFF
--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -46,6 +46,7 @@ module.exports = {
 
         Bus.$on('updateUser', function () {
             self.getUser();
+            self.getCurrentTeam();
         });
 
         Bus.$on('updateUserData', function() {


### PR DESCRIPTION
The updateUser event is triggered when removing a team. This is usefull because the current team will automatically be switched when this is the team being removed.

Adding the getCurrentTeam method to this event will update the currentTeam payload in the Spark instance, this can be usefull when creating custom team switchers.