### PR TITLE
use 'user' instead of 'member' for consistency

### DIFF
--- a/src/Events/Teams/TeamMemberAdded.php
+++ b/src/Events/Teams/TeamMemberAdded.php
@@ -16,18 +16,18 @@ class TeamMemberAdded
      *
      * @var mixed
      */
-    public $member;
+    public $user;
 
     /**
      * Create a new event instance.
      *
      * @param  \Laravel\Spark\Team  $team
-     * @param  mixed  $member
+     * @param  mixed  $user
      * @return void
      */
-    public function __construct($team, $member)
+    public function __construct($team, $user)
     {
         $this->team = $team;
-        $this->member = $member;
+        $this->user = $user;
     }
 }

--- a/src/Events/Teams/TeamMemberRemoved.php
+++ b/src/Events/Teams/TeamMemberRemoved.php
@@ -16,18 +16,18 @@ class TeamMemberRemoved
      *
      * @var mixed
      */
-    public $member;
+    public $user;
 
     /**
      * Create a new event instance.
      *
      * @param  \Laravel\Spark\Team  $team
-     * @param  mixed  $member
+     * @param  mixed  $user
      * @return void
      */
-    public function __construct($team, $member)
+    public function __construct($team, $user)
     {
         $this->team = $team;
-        $this->member = $member;
+        $this->user = $user;
     }
 }


### PR DESCRIPTION
Other user-focused events use "user" naming convention, makes it easier to use the same member variables in the event hook classes.