### PR TITLE
Use the set lang path

### DIFF
--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -53,10 +53,10 @@ trait ProvidesScriptVariables
      */
     private static function getTranslations()
     {
-        $translationFile = resource_path('lang/'.app()->getLocale().'.json');
+        $translationFile = lang_path(app()->getLocale().'.json');
 
         if (! is_readable($translationFile)) {
-            $translationFile = resource_path('lang/'.app('translator')->getFallback().'.json');
+            $translationFile = lang_path(app('translator')->getFallback().'.json');
         }
 
         return json_decode(file_get_contents($translationFile), true);


### PR DESCRIPTION
### What's new 

- Replaced `resource_path` function by `lang_path` to get the set lang directory. 

It could be `/lang` or `/resources/lang` how is shown in these lines:
```php
$this->useLangPath(value(function () {
            return is_dir($directory = $this->resourcePath('lang'))
                        ? $directory
                        : $this->basePath('lang');
        }));
```
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Application.php#L350

**Context**
After [9.x upgrade](https://laravel.com/docs/9.x/upgrade#the-lang-directory) the lang directory changed. This PR helps with that.
