### PR TITLE
Adds #[\ReturnTypeWillChange] to jsonSerialize

### DIFF
--- a/src/Plan.php
+++ b/src/Plan.php
@@ -209,6 +209,7 @@ class Plan implements JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
This PR will suppress the following warning in `/laravel/spark-aurelius/src/Plan.php` :

```
Return type of Laravel\Spark\Plan::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../laravel/spark-aurelius/src/Plan.php on line 212
```